### PR TITLE
Fixing hardcoded / for path issues on Windows

### DIFF
--- a/src/main/java/edu/ucar/unidata/rosetta/controller/TemplateController.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/controller/TemplateController.java
@@ -412,8 +412,9 @@ public class TemplateController implements HandlerExceptionResolver {
                             FilenameUtils.removeExtension(file.getFileName())
                                     + ".nc");
 
-                    return fileOut.replaceAll(downloadDir + "/", "") + "\n"
-                            + jsonOut.replaceAll(downloadDir + "/", "");
+					String escapedDownloadDir = StringEscapeUtils.escapeJava(downloadDir + File.separator);
+					return fileOut.replaceAll(escapedDownloadDir, "") + "\n"
+							+ jsonOut.replaceAll(escapedDownloadDir, "");
                 }
                 // }
             } else {
@@ -568,7 +569,7 @@ public class TemplateController implements HandlerExceptionResolver {
     public void fileDownload(@PathVariable(value = "uniqueID") String uniqueID,
             @PathVariable(value = "file") String fileName,
             HttpServletResponse response) {
-        String relFileLoc = uniqueID + "/" + fileName;
+        String relFileLoc = uniqueID + File.separator + fileName;
         String fullFilePath = FilenameUtils
                 .concat(getDownloadDir(), relFileLoc);
         File requestedFile = new File(fullFilePath);

--- a/src/main/java/edu/ucar/unidata/rosetta/converters/EolSoundingComp.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/converters/EolSoundingComp.java
@@ -6,6 +6,7 @@ import ucar.nc2.*;
 import ucar.nc2.units.SimpleUnit;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -360,7 +361,7 @@ public class EolSoundingComp {
                 // a given block of data within the ESC file. Now time to setup the netCDF
                 // file for this block of data!
                 String ncFile = launchDateIsoStr.replace(":", "") + "-" + siteId + ".nc";
-                String ncFileName = escPath.getParent().toString() + "/" + ncFile;
+                String ncFileName = escPath.getParent().toString() + File.separator + ncFile;
                 if (writeNcFile(ncFileName)) {
                     convertedFiles.add(ncFileName);
                 }

--- a/src/main/java/edu/ucar/unidata/rosetta/dsg/NetcdfFileManager.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/dsg/NetcdfFileManager.java
@@ -649,7 +649,7 @@ public abstract class NetcdfFileManager {
 
     public String createNetcdfFile(AsciiFile file, List<List<String>> parseFileData, String downloadDirPath) throws IOException {
         try {
-            String ncFilePath = downloadDirPath + "/" + FilenameUtils.removeExtension(file.getFileName()) + ".nc";
+            String ncFilePath = downloadDirPath + File.separator + FilenameUtils.removeExtension(file.getFileName()) + ".nc";
             logger.warn("create ncFilePath: " + ncFilePath);
 
             // make sure downloadDir exists and, if not, create it

--- a/src/main/java/edu/ucar/unidata/rosetta/dsg/SingleStationTrajectory2.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/dsg/SingleStationTrajectory2.java
@@ -245,7 +245,7 @@ public class SingleStationTrajectory2  {
     public String createNetcdfFile(AsciiFile file, List<List<String>> parseFileData, String downloadDirPath) throws IOException {
         String ncFilePath = "";
         try {
-            ncFilePath = downloadDirPath + "/" + FilenameUtils.removeExtension(file.getFileName()) + ".nc";
+            ncFilePath = downloadDirPath + File.separator + FilenameUtils.removeExtension(file.getFileName()) + ".nc";
             logger.warn("create ncFilePath: " + ncFilePath);
 
             // make sure downloadDir exists and, if not, create it

--- a/src/main/java/edu/ucar/unidata/rosetta/service/ResourceManagerImpl.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/service/ResourceManagerImpl.java
@@ -41,7 +41,7 @@ public class ResourceManagerImpl implements ResourceManager  {
     public Map<String, Object> loadResources() {     
         Map<String, Object> model = new HashMap<String, Object>();
         try {
-            Resource r = new ClassPathResource("resources/index.xml");
+            Resource r = new ClassPathResource("resources" + File.separator + "index.xml");
             File file = r.getFile();
             List<Map> resources = fetchResources(file, "resource");
             Iterator<Map> iterator = resources.iterator();
@@ -49,7 +49,7 @@ public class ResourceManagerImpl implements ResourceManager  {
 		        Map<String, String> resource = iterator.next();
                 String fileName = resource.get("fileName");
                 String type = resource.get("type");
-                r = new ClassPathResource("resources/" + fileName);
+                r = new ClassPathResource("resources" + File.separator + fileName);
                 file = r.getFile();
                 List<Map> resourceList = fetchResources(file, type); 
                 model.put(type + "s", resourceList); 

--- a/src/main/java/edu/ucar/unidata/rosetta/service/ResourceManagerImpl.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/service/ResourceManagerImpl.java
@@ -41,7 +41,7 @@ public class ResourceManagerImpl implements ResourceManager  {
     public Map<String, Object> loadResources() {     
         Map<String, Object> model = new HashMap<String, Object>();
         try {
-            Resource r = new ClassPathResource("resources" + File.separator + "index.xml");
+            Resource r = new ClassPathResource("resources/index.xml");
             File file = r.getFile();
             List<Map> resources = fetchResources(file, "resource");
             Iterator<Map> iterator = resources.iterator();
@@ -49,7 +49,7 @@ public class ResourceManagerImpl implements ResourceManager  {
 		        Map<String, String> resource = iterator.next();
                 String fileName = resource.get("fileName");
                 String type = resource.get("type");
-                r = new ClassPathResource("resources" + File.separator + fileName);
+                r = new ClassPathResource("resources/" + fileName);
                 file = r.getFile();
                 List<Map> resourceList = fetchResources(file, type); 
                 model.put(type + "s", resourceList); 


### PR DESCRIPTION
This should fix issue #19 

The only place I believe could still be an issue is the default value for the ROSETTA_HOME variable. Though, using the default relative path causes issues with FilenameUtils.concat in getConfigFile() on Windows so it does not seem to work one way or the other anyway.