### PR TITLE
Fix locale decimal mark

### DIFF
--- a/src/main/java/edu/ucar/unidata/rosetta/controller/TemplateController.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/controller/TemplateController.java
@@ -96,7 +96,7 @@ public class TemplateController implements HandlerExceptionResolver {
     @RequestMapping(value = "/create", method = RequestMethod.GET)
     public ModelAndView createTemplate(Model model) {
         model.addAllAttributes(resourceManager.loadResources());
-		model.addAttribute("maxUploadSize", RosettaProperties.getMaxUploadSize(servletContext));
+        model.addAttribute("maxUploadSize", RosettaProperties.getMaxUploadSize(servletContext));
         return new ModelAndView("create");
     }
 
@@ -150,6 +150,7 @@ public class TemplateController implements HandlerExceptionResolver {
     public ModelAndView restoreTemplate(Model model) {
         BasicConfigurator.configure();
         model.addAllAttributes(resourceManager.loadResources());
+        model.addAttribute("maxUploadSize", RosettaProperties.getMaxUploadSize(servletContext));
         return new ModelAndView("restore");
     }
 

--- a/src/main/java/edu/ucar/unidata/rosetta/domain/AsciiFile.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/domain/AsciiFile.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 
@@ -26,6 +27,7 @@ public class AsciiFile {
     private String fileName = null;
     private String delimiters = null;
     private List<String> delimiterList = new ArrayList<String>();
+    private Locale decimalSeparatorLocale = Locale.ENGLISH;
     private String otherDelimiter = null;
     private String headerLineNumbers = null;
     private List<String> headerLineList = new ArrayList<String>();
@@ -440,5 +442,31 @@ public class AsciiFile {
             }
 	    } 
         return convertedDelimiterList;
+    }
+
+    public Locale getDecimalSeparatorLocale() {
+        return decimalSeparatorLocale;
+    }
+
+    /**
+     * Sets the locale to FRENCH if "Comma" is given as input.
+     * 
+     * Else it sets it to ENGLISH (for Point as separator), which is the
+     * default.
+     * 
+     * @param decimalSeparator
+     *            Text representation of the decimal separator to be used
+     * 
+     */
+    public void setDecimalSeparator(String decimalSeparator) {
+        switch (decimalSeparator) {
+            case "Comma" :
+                this.decimalSeparatorLocale = Locale.FRENCH;
+                break;
+            case "Point" :
+            default :
+                this.decimalSeparatorLocale = Locale.ENGLISH;
+                break;
+        }
     }
 }

--- a/src/main/java/edu/ucar/unidata/rosetta/dsg/NetcdfFileManager.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/dsg/NetcdfFileManager.java
@@ -12,6 +12,8 @@ import ucar.nc2.Variable;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.*;
 
 /**
@@ -572,7 +574,9 @@ public abstract class NetcdfFileManager {
         return ncFileWriter;
     }
 
-    protected NetcdfFileWriter writeUserVarData(List<List<String>> outerList, NetcdfFileWriter ncFileWriter) throws IOException, InvalidRangeException {
+    protected NetcdfFileWriter writeUserVarData(List<List<String>> outerList, NetcdfFileWriter ncFileWriter, Locale locale)
+            throws IOException, InvalidRangeException, ParseException {
+        NumberFormat nFormat = NumberFormat.getInstance(locale);
         for (String var : getAllVarNames()) {
             Variable theVar = ncFileWriter.findVariable(var);
             if (theVar != null) {
@@ -587,9 +591,8 @@ public abstract class NetcdfFileManager {
                                 new ArrayFloat.D1(outerList.size());
                         int      i                 = 0;
                         for (List<String> innerList : outerList) {
-                            float f = Float.parseFloat(
-                                    innerList.get(
-                                            varIndex));
+                            Number number = nFormat.parse(innerList.get(varIndex));
+                            float f = number.floatValue();
                             vals.set(i, f);
                             i++;
                         }
@@ -689,7 +692,7 @@ public abstract class NetcdfFileManager {
 
             ncFileWriter = writeRosettaInfo(ncFileWriter, file.getJsonStrSessionStorage());
             // must write user data before any new dateTime variables!
-            ncFileWriter = writeUserVarData(parseFileData, ncFileWriter);
+            ncFileWriter = writeUserVarData(parseFileData, ncFileWriter, file.getDecimalSeparatorLocale());
             if (getDateTimeBluePrint() != null) {
                 if (!getDateTimeBluePrint().isEmpty()) {
                     ncFileWriter = getDateTimeBluePrint().writeNewVariables(ncFileWriter);

--- a/src/main/webapp/WEB-INF/classes/messages.properties
+++ b/src/main/webapp/WEB-INF/classes/messages.properties
@@ -16,6 +16,7 @@ step2.title=Specify Header Lines
 step2.description=Indicate which lines are header (i.e. not data) lines, or select 'No Header Lines' if there are none.
 step3.title=Specify Delimiters
 step3.description=Please specify delimiter(s) used.
+step3.subDescription=Please specify decimal separator used.
 step4.title=Specify Variable Attributes
 step4.description=
 step5.title=Specify Site Specific Information

--- a/src/main/webapp/WEB-INF/views/create.jsp
+++ b/src/main/webapp/WEB-INF/views/create.jsp
@@ -37,6 +37,8 @@
             <div id="step3" title="<spring:message code="step3.title"/>">
                 <h5><spring:message code="step3.description"/></h5>
                 <%@include file="/WEB-INF/views/jspf/specifyDelimiters.jspf" %>
+                <h5><spring:message code="step3.subDescription"/></h5>
+                <%@include file="/WEB-INF/views/jspf/specifyDecimalSeparator.jspf" %>
             </div>
 
             <div id="step4" title="<spring:message code="step4.title"/>">

--- a/src/main/webapp/WEB-INF/views/jspf/specifyDecimalSeparator.jspf
+++ b/src/main/webapp/WEB-INF/views/jspf/specifyDecimalSeparator.jspf
@@ -1,0 +1,2 @@
+<input type="radio" name="decimalSeparator" id="decimalSeparator" value="Point" checked="checked"/>Point<br>
+<input type="radio" name="decimalSeparator" id="decimalSeparator" value="Comma"/>Comma

--- a/src/main/webapp/WEB-INF/views/jspf/specifyDelimiters.jspf
+++ b/src/main/webapp/WEB-INF/views/jspf/specifyDelimiters.jspf
@@ -1,7 +1,7 @@
 <label for="delimiter" class="error"></label>
 <c:choose>
     <c:when test="${fn:length(delimiters) gt 0}">
-        <ul>
+        <ul id="delimiterList">
             <c:forEach items="${delimiters}" var="delimiter">
                 <li>
                     <label>

--- a/src/main/webapp/WEB-INF/views/restore.jsp
+++ b/src/main/webapp/WEB-INF/views/restore.jsp
@@ -12,6 +12,7 @@
             var platformMetadata = [];
             var generalMetadata = [];
             var publisherInfo = [];
+            var maxUploadSize = ${maxUploadSize};
             $.metadata.setType("attr", "validate");
         </script>
     </head>

--- a/src/main/webapp/WEB-INF/views/restore.jsp
+++ b/src/main/webapp/WEB-INF/views/restore.jsp
@@ -36,8 +36,10 @@
             </div>
 
             <div id="step3" title="<spring:message code="step3.title"/>">
-               <h5><spring:message code="step3.description"/></h5>
-               <%@include file="/WEB-INF/views/jspf/specifyDelimiters.jspf" %>
+                <h5><spring:message code="step3.description"/></h5>
+                <%@include file="/WEB-INF/views/jspf/specifyDelimiters.jspf" %>
+                <h5><spring:message code="step3.subDescription"/></h5>
+                <%@include file="/WEB-INF/views/jspf/specifyDecimalSeparator.jspf" %>
             </div>
 
             <div id="step4" title="<spring:message code="step4.title"/>">

--- a/src/main/webapp/frontEndResources/css/create.css
+++ b/src/main/webapp/frontEndResources/css/create.css
@@ -81,6 +81,12 @@ label.noHeaderLines {
  font-family: "Courier New", Courier, monospace;
 }
 
+/* The delimiter list needs this to have decimal separator selection placed properly */
+ul#delimiterList {
+ width: 100%;
+ position: relative; 
+}
+
 /* unordered lists are used to display/format form items in the jWizard */
 ul {
  width: 70%;

--- a/src/main/webapp/frontEndResources/css/restore.css
+++ b/src/main/webapp/frontEndResources/css/restore.css
@@ -87,6 +87,12 @@ label.error {
  color: #FF0000;
 }
 
+/* The delimiter list needs this to have decimal separator selection placed properly */
+ul#delimiterList {
+ width: 100%;
+ position: relative; 
+}
+
 /* unordered lists are used to display/format form items in the jWizard */
 ul {
  width: 70%;

--- a/src/main/webapp/frontEndResources/js/stepFunctions.js
+++ b/src/main/webapp/frontEndResources/js/stepFunctions.js
@@ -321,6 +321,13 @@ function specifyDelimiters(stepType, stepData) {
                 $("#faux").remove();
                 $(".jw-button-next").removeClass("hideMe");
             }
+            if (getFromSession("decimalSeparator")) {
+                $("#step3 #decimalSeparator").each(function(){
+                    if (getFromSession("decimalSeparator").search($(this).val()) >= 0 ) {
+                        $(this).attr("checked", true);
+                    }
+                });
+            }
         }
     } else if (stepType == "stepFunctions") {
         var stepElement = "#step" + stepData + " input:checkbox";
@@ -356,6 +363,10 @@ function specifyDelimiters(stepType, stepData) {
                     $("#otherDelimiter").removeClass("hideMe");
                 }
             }
+        });
+        
+        $("#step3 #decimalSeparator").bind("click", function(){
+        	addToSession("decimalSeparator", $('input[name=decimalSeparator]:checked', '#step3').val());
         });
 
         $("#otherDelimiter").on("focusin", function() {

--- a/src/main/webapp/frontEndResources/js/stepFunctions.js
+++ b/src/main/webapp/frontEndResources/js/stepFunctions.js
@@ -185,7 +185,7 @@ function uploadRosettaTemplate(stepType, stepData) {
     } else if (stepType == "repopulateStep") {
         $(fileId).bind("change", function() {
             // Validate file being uploaded
-            var error = validateUploadedFile($("#file")[0].files[0], 1);
+            var error = validateUploadedTemplateFile($(fileId)[0].files[0], 0);
             if (!error) {
                 return false;
             } else {
@@ -210,7 +210,7 @@ function uploadRosettaTemplate(stepType, stepData) {
     } else if (stepType == "stepFunctions") {
         $(fileId).bind("change", function() {
             // Validate file being uploaded
-            var error = validateUploadedTemplateFile($(fileId)[0].files[0], 1);
+            var error = validateUploadedTemplateFile($(fileId)[0].files[0], 0);
             if (!error) {
                 return false;
             } else {


### PR DESCRIPTION
This should solve issue #22 by adding the option to specify comma as decimal separator in the "specify delimiters tab".

This also fixes a tiny bug where maxUploadSize was not set on the restore page.

It also fixes what I believe to be a small bug in calling validateUploadedTemplateFile, but I refer to issue #26 to resolve this.

There is still work to be done to add this to the decimal separator to the template file.

The two bugs are in smaller hotfix-branches as well, but I thought I should open this pull request to get the whole discussion going.
