### PR TITLE
Simplified/standardised the calling of repopulate

### DIFF
--- a/src/main/webapp/frontEndResources/js/create.js
+++ b/src/main/webapp/frontEndResources/js/create.js
@@ -104,17 +104,11 @@ $(document).ready(function ($) {
                     break;
 
                 case 5:
-                    var stepDataCase5 = new Array()
-                    stepDataCase5[0] = ui;
-                    stepDataCase5[1] = 5;
-                    specifyPlatformMetadata("repopulateStep", stepDataCase5);
+                    specifyPlatformMetadata("repopulateStep", ui);
                     break;
 
                 case 6:
-                    var stepDataCase6 = new Array()
-                    stepDataCase6[0] = ui;
-                    stepDataCase6[1] = 6;
-                    specifyGeneralMetadata("repopulateStep", stepDataCase6);
+                    specifyGeneralMetadata("repopulateStep", ui);
                     break;
 
                 case 7:

--- a/src/main/webapp/frontEndResources/js/restore.js
+++ b/src/main/webapp/frontEndResources/js/restore.js
@@ -108,17 +108,11 @@ $(document).ready(function ($) {
                     break;
 
                 case 5:
-                    var stepDataCase5 = new Array()
-                    stepDataCase5[0] = ui;
-                    stepDataCase5[1] = 5;
-                    specifyPlatformMetadata("repopulateStep", stepDataCase5);
+                    specifyPlatformMetadata("repopulateStep", ui);
                     break;
 
                 case 6:
-                    var stepDataCase6 = new Array()
-                    stepDataCase6[0] = ui;
-                    stepDataCase6[1] = 6;
-                    specifyGeneralMetadata("repopulateStep", stepDataCase6);
+                    specifyGeneralMetadata("repopulateStep", ui);
                     break;
 
                 case 7:

--- a/src/main/webapp/frontEndResources/js/stepFunctions.js
+++ b/src/main/webapp/frontEndResources/js/stepFunctions.js
@@ -431,7 +431,7 @@ function specifyGeneralMetadata(stepType, stepData) {
             }
         }
     } else if (stepType == "repopulateStep") {
-        if ((stepData[0].type == "previous") || (stepData[0].type == "next")) {
+        if ((stepData.type == "previous") || (stepData.type == "next")) {
             if (getItemEntered("generalMetadata", "title") != null) {
                 if (getItemEntered("generalMetadata", "institution") != null) {
                     if (getItemEntered("generalMetadata", "description") != null) {
@@ -441,7 +441,7 @@ function specifyGeneralMetadata(stepType, stepData) {
                 }
             }
         }
-        var stepElement = "#step" + stepData[1] + " input";
+        var stepElement = "#step" + stepData.nextStepIndex + " input";
         var inputElements = $(stepElement);
         for (var i = 0; i < inputElements.length; i++) {
             var name = $(inputElements[i]).attr("name");
@@ -493,7 +493,7 @@ function specifyPlatformMetadata(stepType, stepData) {
             }
         }
     } else if (stepType == "repopulateStep") {
-        if ((stepData[0].type == "previous") || (stepData[0].type == "next")) {
+        if ((stepData.type == "previous") || (stepData.type == "next")) {
             if (getItemEntered("platformMetadata", "platformName") != null) {
                 if (getItemEntered("platformMetadata", "latitude") != null) {
                     if (getItemEntered("platformMetadata", "longitude") != null) {
@@ -507,7 +507,7 @@ function specifyPlatformMetadata(stepType, stepData) {
         }
 
         // populate input elements from sessionStorage
-        var stepElement = "#step" + stepData[1] + " input";
+        var stepElement = "#step" + stepData.nextStepIndex + " input";
         var inputElements = $(stepElement);
         for (var i = 0; i < inputElements.length; i++) {
             var name = $(inputElements[i]).attr("name");
@@ -520,7 +520,7 @@ function specifyPlatformMetadata(stepType, stepData) {
         }
 
         // populate select elements from sessionStorage
-        var stepElementSelect = "#step" + stepData[1] + " select";
+        var stepElementSelect = "#step" + stepData.nextStepIndex + " select";
         var inputElementsSelect = $(stepElementSelect);
         for (var i = 0; i < inputElementsSelect.length; i++) {
             var name = $(inputElementsSelect[i]).attr("name");


### PR DESCRIPTION
IT seems to me to be completely unnecessary to hardcode 5 and 6 for repopulating the two metadata tabs as ui.nextStepIndex always seems to be the respecitve number.

I can not think of a test case where this is not the scenario. And simplifying this code and make it calling the repopulateStep in the same way as the others seems like the obvious way to do it.