### PR TITLE
Implemented "proper" escaping of comma and colon in the inputstrings

### DIFF
--- a/src/main/java/edu/ucar/unidata/rosetta/domain/AsciiFile.java
+++ b/src/main/java/edu/ucar/unidata/rosetta/domain/AsciiFile.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 
 /**
@@ -269,12 +270,14 @@ public class AsciiFile {
      * Creates a Map containing the platform metadata as specified by the user.
      */
     public void setPlatformMetadataMap() {
-        List<String> pairs = Arrays.asList(platformMetadata.split(","));
+        String regexComma = "(?<!\\\\)" + Pattern.quote(",");
+        String regexColon = "(?<!\\\\)" + Pattern.quote(":");
+        List <String> pairs = Arrays.asList(platformMetadata.split(regexComma));
         Iterator<String> pairsIterator = pairs.iterator();
         while (pairsIterator.hasNext()) {
             String pairString = pairsIterator.next();
-            String[] items = pairString.split(":");
-            this.platformMetadataMap.put(items[0], items[1]);
+            String[] items =  pairString.split(regexColon);
+            this.platformMetadataMap.put(items[0], items[1].replaceAll("\\\\:", ":").replaceAll("\\\\,", ","));
         }
     }
 
@@ -312,12 +315,16 @@ public class AsciiFile {
      * @param generalMetadata The String of general metadata.
      */
     public void setGeneralMetadataMap(String generalMetadata) {
-        List<String> pairs = Arrays.asList(generalMetadata.split(","));
+        String regexComma = "(?<!\\\\)" + Pattern.quote(",");
+        String regexColon = "(?<!\\\\)" + Pattern.quote(":");
+        System.out.println("setGeneralMetadataMap:");
+        System.out.println(generalMetadata);
+        List<String> pairs = Arrays.asList(generalMetadata.split(regexComma));
         Iterator<String> pairsIterator = pairs.iterator();
         while (pairsIterator.hasNext()) {
             String pairString = pairsIterator.next();
-            String[] items = pairString.split(":");
-            this.generalMetadataMap.put(items[0], items[1]);
+            String[] items = pairString.split(regexColon);
+            this.generalMetadataMap.put(items[0], items[1].replaceAll("\\\\:", ":").replaceAll("\\\\,", ","));
         }
     }
 
@@ -394,25 +401,24 @@ public class AsciiFile {
      * Creates a Map containing the variable metadata as specified by the user.
      */
     public void setVariableMetadataMap() {
-        String colonReplacement = "DotDot";
-        List<String> pairs = Arrays.asList(variableMetadata.split(","));
+        String regexComma = "(?<!\\\\)" + Pattern.quote(",");
+        String regexColon = "(?<!\\\\)" + Pattern.quote(":");
+        String regexPlus = "(?<!\\\\)" + Pattern.quote("+");
+        List <String> pairs = Arrays.asList(variableMetadata.split(regexComma));
         Iterator<String> pairsIterator = pairs.iterator();
         while (pairsIterator.hasNext()) {
             HashMap<String, String> metadataMapping = new HashMap<String, String>();
             String pairString = pairsIterator.next();
             String[] items = pairString.split("=");
             if (!items[1].equals("Do Not Use")) {
-                List<String> values = Arrays.asList(items[1].split("\\+"));
+                List <String> values =  Arrays.asList(items[1].split(regexPlus));
                 Iterator<String> valuesIterator = values.iterator();
                 while (valuesIterator.hasNext()) {
                     String data = valuesIterator.next();
-                    String[] metadata = data.split(":");
+                    String[] metadata = data.split(regexColon);
                     String metadataName = metadata[0];
                     String value = metadata[1];
-                    if (value.contains(colonReplacement)) {
-                        value = value.replaceAll(colonReplacement, ":");
-                    }
-                    metadataMapping.put(metadataName, value);
+                    metadataMapping.put(metadataName, value.replaceAll("\\\\:", ":").replaceAll("\\\\,", ","));
                 }
             }
             this.variableMetadataMap.put(items[0], metadataMapping);

--- a/src/main/webapp/frontEndResources/js/SlickGrid/custom/variableSpecification.js
+++ b/src/main/webapp/frontEndResources/js/SlickGrid/custom/variableSpecification.js
@@ -20,9 +20,6 @@ String.prototype.replaceAll = function (target, replacement) {
     return this.split(target).join(replacement);
 };
 
-// string to replace : in units...used for sessionStorage.
-var colonReplacement = "DotDot";
-
 /**
  * This function creates a SlickGrid displaying the parsed file data by by row
  * and delimiter. The user will use the SlickGrid interface and the HeaderButtons
@@ -517,10 +514,6 @@ function bindGeneralMetadataEvents(sessionKey) {
 
         // concatenation the entered value to any existing Metadata values pulled from the session
         var generalMetadataValue = $(this).attr("value");
-        if ($(this).attr("name") == "units") {
-            generalMetadataValue = generalMetadataValue.replaceAll(colonReplacement, ":");
-            generalMetadataValue = generalMetadataValue.replaceAll(":", colonReplacement);
-        }
         var metadataString = buildStringForSession(sessionKey + "Metadata", $(this).attr("name"),
                                                    generalMetadataValue);
 
@@ -687,8 +680,6 @@ function bindUnitBuildEvents(sessionKey) {
 
         // get the user selected values of the unit chooser
         var unitSelected = $("#dialog #unitBuilder select[name=\"unitSelected\"]").val();
-        // for time related units
-        unitSelected = unitSelected.replaceAll(":", colonReplacement);
 
         var prefixSelected = $("#dialog #unitBuilder select[name=\"unitPrefix\"]").val();
         if (prefixSelected != null) {
@@ -720,8 +711,8 @@ function bindUnitBuildEvents(sessionKey) {
             addToSession(sessionKey + "Metadata", metadataString);
 
             // update units display in dialog to show new value
-            $("#dialog #requiredMetadataAssignment input[name=\"units\"]")
-                .attr("value", unitsInSession.replaceAll(colonReplacement, ":"));
+            $("#dialog #requiredMetadataAssignment input[name=\"units\"]").attr("value",
+                                                                                unitsInSession);
 
             // Removing from units
         } else {

--- a/src/main/webapp/frontEndResources/js/validationFunctions.js
+++ b/src/main/webapp/frontEndResources/js/validationFunctions.js
@@ -291,14 +291,15 @@ function validateVariableData(sessionKey, finalCheck) {
                                     if (metadataProvided.length > 0) {
                                         // make sure chars are correct and no blank entries
                                         for (var i = 0; i < metadataProvided.length; i++) {
-                                            var metadataKeyValuePair = metadataProvided[i].split(
-                                                /:/);
+                                            var metadataKeyValuePair = metadataProvided[i].match(/(\\.|[^:])+/g);
 
-                                            // all entries have to pass this test
-                                            errorMessage =
-                                                lookForBadChars(metadataKeyValuePair[1],
-                                                                getMetadataDisplayName(
-                                                                    metadataKeyValuePair[0]));
+                                            // all entries have to pass this test if it has a value
+                                            if (metadataKeyValuePair.length > 1){
+                                                errorMessage =
+                                                    lookForBadChars(metadataKeyValuePair[1],
+                                                                    getMetadataDisplayName(
+                                                                        metadataKeyValuePair[0]));
+                                            }
                                             if (errorMessage != null) {
                                                 $("#dialog #variableAttributes label[for=\""
                                                   + metadataKeyValuePair[0] + "\"].error")
@@ -306,8 +307,12 @@ function validateVariableData(sessionKey, finalCheck) {
                                                 removeItemFromSessionString(sessionKey + "Metadata",
                                                                             metadataKeyValuePair[0]);
                                             } else {
+                                                var value = "";
+                                                if (metadataKeyValuePair.length > 1){
+                                                    value = metadataKeyValuePair[1];
+                                                }
                                                 errorMessage =
-                                                    lookForBlankEntries(metadataKeyValuePair[1],
+                                                    lookForBlankEntries(value,
                                                                         metadataKeyValuePair[0]);
                                                 if (errorMessage != null) {
                                                     // only required metadata must pass this


### PR DESCRIPTION
This will escape `:` and `,` for all strings that are prepared with `buildStringForSession()`

`+=` are not escaped as they are used as delimiter only in variable input, and there is an input validation on the form itself that only allows the following characters: `a-zA-Z0-9 _-.`

An option to this would be to just allow the above characters in all input fields. But I'd prefer my solution, hence the PR.