### PR TITLE
import of ServerInfoBean added to restore

### DIFF
--- a/src/main/webapp/WEB-INF/views/restore.jsp
+++ b/src/main/webapp/WEB-INF/views/restore.jsp
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <%@ include file="/WEB-INF/views/includes/taglibs.jsp" %>
+<%@ page import="edu.ucar.unidata.rosetta.service.ServerInfoBean" %>
 <html>
 <head>
     <title><spring:message code="global.title"/></title>


### PR DESCRIPTION
For some reason, the restore page stopped working on my develop machine.

A manual import of the bean, like this, solves the issue. It has probably something to do with my setup and some spring magic I don't understand. But I believe this import is correct to do anyway. It is imported in index.jsp, create.jsp and autoconvert.jsp already.

Please enlighten me if this is not the correct approach.