### PR TITLE
Implemented custom global attributes

### DIFF
--- a/src/main/webapp/WEB-INF/views/jspf/specifyGeneralMetadata.jspf
+++ b/src/main/webapp/WEB-INF/views/jspf/specifyGeneralMetadata.jspf
@@ -46,6 +46,7 @@
                            class="error"></label>
                 </li>
             </c:forEach>
+            <div id="containerForCustomAttributes"/>
         </ul>
     </c:when>
     <c:otherwise>

--- a/src/main/webapp/frontEndResources/css/create.css
+++ b/src/main/webapp/frontEndResources/css/create.css
@@ -90,7 +90,6 @@ ul {
     margin: 0 0 10px 0;
     padding: 0;
     float: left;
-    position: absolute;
 }
 
 ul li {

--- a/src/main/webapp/frontEndResources/css/jWizard/custom.css
+++ b/src/main/webapp/frontEndResources/css/jWizard/custom.css
@@ -66,7 +66,8 @@
 .jw-steps-wrap {
     padding: 0 0 0 20px;
     margin: 40px 0 0 0;
-    height: 400px;
+    height: auto;
+    min-height: 270px;
 }
 
 /* footer section that displays the navigation buttons */

--- a/src/main/webapp/frontEndResources/js/sessionFunctions.js
+++ b/src/main/webapp/frontEndResources/js/sessionFunctions.js
@@ -121,6 +121,21 @@ function getItemEntered(sessionKey, dataSought) {
     }
     return null;
 }
+function searchForValue(sessionKey, valueSought, exceptFrom) {
+    var escapedValueSought = escapeCharacters(valueSought);
+    var dataInSession = getFromSession(sessionKey);
+    if (dataInSession) {
+        var pairs = dataInSession.match(/(\\.|[^,])+/g);
+        for (var i = 0; i < pairs.length; i++) { 
+            var keyValuePair = pairs[i].match(/(\\.|[^:])+/g);
+            if (keyValuePair[1] == escapedValueSought &&
+                    keyValuePair[0] != exceptFrom) {
+                return keyValuePair[0];
+            }
+        }
+    }
+    return false;
+}
 
 function escapeCharacters(value){
     value = value.replace(/:/g,"\\:");
@@ -182,10 +197,10 @@ function buildStringForSession(sessionKey, key, value) {
 }
 
 /**
- * Utility function that just loops through the a string of concatenated
+ * Utility function that just loops through an array of 
  * key/value pairs in the session and returns an array of the keys.
  *
- * @param sessionData  The string of concatenated key/value pairs in the session.
+ * @param sessionData  The array of key/value pairs in the session.
  */
 function getKeysFromSessionData(sessionData) {
     var sessionKeys = [];
@@ -196,7 +211,22 @@ function getKeysFromSessionData(sessionData) {
     }
     return sessionKeys;
 }
-
+/**
+ * Utility function that just loops through a string of concatenated
+ * key/value pairs in the session and returns an array of the values.
+ *
+ * @param sessionString  The string of concatenated key/value pairs in the session.
+ */
+function getValuesFromSessionString(sessionString) {
+    var sessionValues = [];
+    sessionString = sessionString.match(/(\\.|[^,])+/g);
+    // make sure chars are correct and no blank entries
+    for (var i = 0; i < sessionString.length; i++) {
+        var keyValuePair = sessionString[i].match(/(\\.|[^:])+/g);
+        sessionValues.push(unescapeCharacters(keyValuePair[1]));
+    }
+    return sessionValues;
+}
 /**
  * Removes a specific item from the string of concatenated key/value pairs stored in the session.
  *


### PR DESCRIPTION
The user can press a button to add custom attributes in the general metadata tab.

This should solve option 1 in #16. And also help along the way of option 2, as some hard-coded pieces are removed.

Removed harcoded checks for "required" metadata while refactoring checkAndExposeNext to also include checking generalMetadata and that all custom fields has name and value (i.e. no errormessages are produced from the validate function).

The custom attribute names are following CF for naming convention: can only start with a letter, and can only contain letters, numbers and underscores. Further specified letters to be a-zA-Z only.

Duplicate attribute names are not allowed (it checks all existing custom and generalMetadata entries).

CSS: removed absolute position of the ul elements, and set the height for jWizard to auto with a minimum. This solves an issue with bad looking ui for when the added general metadata list gets long.

Also fixed what seemed to be wrong documentation of getKeysFromSessionData as it wants an array as input, not a string.