### PR TITLE
Upgrade log4j2 to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 ext {
-  log4j2Version = '2.16.0'
-
   // needed for Jekyll
   // It makes sense to publish major.minor versions of the docs, as
   // any patch bumps should be backwards compatible bug fixes only
@@ -55,6 +53,7 @@ dependencies {
   implementation enforcedPlatform('org.springframework:spring-framework-bom:5.3.13')
   implementation enforcedPlatform('org.springframework.security:spring-security-bom:5.5.3')
   implementation enforcedPlatform('com.fasterxml.jackson:jackson-bom:2.12.5')
+  implementation enforcedPlatform('org.apache.logging.log4j:log4j-bom:2.17.0')
 
   // Spring Framework
   implementation 'org.springframework:spring-beans'
@@ -115,14 +114,14 @@ dependencies {
   }
 
   // replace log4j 1.x with the log4j 1.2 bridge
-  runtimeOnly"org.apache.logging.log4j:log4j-1.2-api:${log4j2Version}"
+  runtimeOnly 'org.apache.logging.log4j:log4j-1.2-api'
 
   // logging
-  implementation "org.apache.logging.log4j:log4j-api:${log4j2Version}"
-  runtimeOnly"org.apache.logging.log4j:log4j-core:${log4j2Version}"
-  runtimeOnly"org.apache.logging.log4j:log4j-web:${log4j2Version}"
+  implementation 'org.apache.logging.log4j:log4j-api'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-web'
   // edu.ucar:httpservices uses uses Apache Commons Logging 1.x, so add the JCL bridge
-  runtimeOnly"org.apache.logging.log4j:log4j-jcl:${log4j2Version}"
+  runtimeOnly "org.apache.logging.log4j:log4j-jcl"
 
   // Testing
   testImplementation 'de.bechte.junit:junit-hierarchicalcontextrunner:4.12.1'


### PR DESCRIPTION
Use the log4j bom with gradle's enforcedPlatform to control transitive versions of log4j libs as well.